### PR TITLE
Improve Filter performance

### DIFF
--- a/marc.go
+++ b/marc.go
@@ -126,14 +126,14 @@ func (r Record) Filter(query ...string) [][]string {
 					res = append(res, values)
 				}
 			case DataField:
-				parts := strings.Split(q, "|")
+				ind := strings.Index(q, "|")
 				var subs string
 				ind1, ind2 := "*", "*"
-				if len(parts) == 3 {
-					ind1, ind2 = string(parts[1][0]), string(parts[1][1])
-					subs = parts[2]
+				if ind > -1 {
+					ind1, ind2 = string(q[ind+1]), string(q[ind+2])
+					subs = q[ind+4:]
 				} else {
-					subs = parts[0][3:]
+					subs = q[3:]
 				}
 				if f.matches(tag, ind1, ind2) {
 					if len(subs) != 0 {

--- a/marc_test.go
+++ b/marc_test.go
@@ -6,6 +6,31 @@ import (
 	"testing"
 )
 
+func BenchmarkFilter(b *testing.B) {
+	f, err := os.Open("fixtures/record1.mrc")
+	if err != nil {
+		b.Error(err)
+	}
+	iter := NewMarcIterator(f)
+	_ = iter.Next()
+	r := iter.Value()
+	b.Run("Everything", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = r.Filter("650|*0|x")
+		}
+	})
+	b.Run("Tag only", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = r.Filter("650")
+		}
+	})
+	b.Run("Tag-subfield", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = r.Filter("650x")
+		}
+	})
+}
+
 func TestRecord(t *testing.T) {
 	f, err := os.Open("fixtures/record1.mrc")
 	if err != nil {


### PR DESCRIPTION
This change significantly improves the performance of Filter, especially
when querying for indicators. The previous implementation (by using
strings.Split) ended up making an excessive amount of mallocgc calls due
to all the tiny string allocations.