### PR TITLE
Add leader support

### DIFF
--- a/marc.go
+++ b/marc.go
@@ -17,6 +17,20 @@ const (
 // which contains both ControlFields and DataFields.
 type Record struct {
 	Fields []interface{}
+	Leader Leader
+}
+
+// Leader contains a subset of the bytes in the record leader. Omitted are
+// bytes specifying the length of parts of the record and bytes which do
+// not vary from record to record.
+type Leader struct {
+	Status        byte // 05 byte position
+	Type          byte // 06
+	BibLevel      byte // 07
+	Control       byte // 08
+	EncodingLevel byte // 17
+	Form          byte // 18
+	Multipart     byte // 19
 }
 
 // ControlField just contains a Tag and a Value.
@@ -175,6 +189,15 @@ func (m *MarcIterator) Err() error {
 
 func (m *MarcIterator) scanIntoRecord(bytes []byte) Record {
 	rec := Record{}
+	rec.Leader = Leader{
+		Status:        bytes[5],
+		Type:          bytes[6],
+		BibLevel:      bytes[7],
+		Control:       bytes[8],
+		EncodingLevel: bytes[17],
+		Form:          bytes[18],
+		Multipart:     bytes[19],
+	}
 
 	start, err := strconv.Atoi(string(bytes[12:17]))
 	if err != nil {

--- a/marc_test.go
+++ b/marc_test.go
@@ -19,6 +19,11 @@ func TestRecord(t *testing.T) {
 			t.Error("Expected 92005291, got", r.ControlNum())
 		}
 	})
+	t.Run("Leader", func(t *testing.T) {
+		if r.Leader.Type != 'a' {
+			t.Error("Expected a, got", r.Leader.Type)
+		}
+	})
 	t.Run("Specific control field", func(t *testing.T) {
 		cf := r.ControlField("001")[0]
 		if cf.Tag != "001" {


### PR DESCRIPTION
This adds a Leader struct to a Record. Not everything from the leader
will be present in the struct. I left out the parts about byte addresses
and the parts that are the same for every record.