### PR TITLE
Return error instead of panic when Invalid indicators present

### DIFF
--- a/marc.go
+++ b/marc.go
@@ -244,8 +244,12 @@ func NewMarcIterator(r io.Reader) *MarcIterator {
 func makeDataField(tag string, data []byte) (DataField, error) {
 	d := DataField{}
 	d.Tag = tag
-	d.Indicator1 = string(data[0])
-	d.Indicator2 = string(data[1])
+	if len(data) > 2 {
+		d.Indicator1 = string(data[0])
+		d.Indicator2 = string(data[1])
+	} else {
+		return d, errors.New("Invalid Indicators detected")
+	}
 	for _, sf := range bytes.Split(data[3:], []byte{st}) {
 		if len(sf) > 0 {
 			d.SubFields = append(d.SubFields, SubField{string(sf[0]), string(sf[1:])})


### PR DESCRIPTION
This was necessary due to our local record `002621436`.

Before the fix, we'd panic with an index out of range.

Now we pass this error and Mario can continue with the next record:
```
2019/01/14 11:37:07 Error parsing MARC record: 002621436
2019/01/14 11:37:07 Invalid Indicators detected
2019/01/14 11:37:07 {[{001 002621436} {005 20180629004505.0} {006 m     o  d        } {007 cr cnu|||unuuu} {008 180221s2018    nju     o     001 0 eng d} {    FMT [{K }]} {    020 [{a 9781119188421} {q (electronic bk. ;} {q oBook)}]} {    020 [{a 1119188423} {q (electronic bk. ;} {q oBook)}]} {    020 [{z 978119188391} {q (cloth)}]} {    020 [{z 9781119188391}]} {    020 [{z 1119188393}]} {7   024 [{a 10.1002/9781119188421} {2 doi}]} {    035 [{a (OCoLC)1023810884}]} {    035 [{a (OCoLC)1035062525}]} {    035 [{a (OCoLC)1035303176}]} {    040 [{a DG1} {b eng} {e rda} {e pn} {c DG1} {d OCLCF} {d NLE} {d OCLCQ} {d UAB} {d OCLCQ} {d UPM} {d YDX} {d OCLCO} {d STF}]} {  4 050 [{a RC857}]} {  4 060 [{a WI 800}]} {0 4 082 [{a 616.3/7} {2 23}]} {0 4 245 [{a The pancreas :} {b an integrated textbook of basic science, medicine, and surgery /} {c edited by Hans G. Beger [and more].}]} {    250 [{a Third edition.}]} {  1 264 [{a Hoboken, NJ :} {b Wiley Blackwell,} {c 2018.}]} {    300 [{a 1 online resource}]} {    336 [{a text} {b txt} {2 rdacontent}]} {    337 [{a computer} {b c} {2 rdamedia}]} {    338 [{a online resource} {b cr} {2 rdacarrier}]}] {99 97 109 32 73 105 32}}
```