### PR TITLE
Heap usage

### DIFF
--- a/cmd/fml/main.go
+++ b/cmd/fml/main.go
@@ -26,7 +26,7 @@ func main() {
 				for m.Next() {
 					record, _ := m.Value()
 					if record.ControlNum() == id {
-						os.Stdout.Write(record.Data)
+						os.Stdout.WriteString(record.Data)
 						break
 					}
 				}

--- a/marc_test.go
+++ b/marc_test.go
@@ -15,16 +15,19 @@ func BenchmarkFilter(b *testing.B) {
 	_ = iter.Next()
 	r, _ := iter.Value()
 	b.Run("Everything", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			_ = r.Filter("650|*0|x")
 		}
 	})
 	b.Run("Tag only", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			_ = r.Filter("650")
 		}
 	})
 	b.Run("Tag-subfield", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			_ = r.Filter("650x")
 		}
@@ -32,6 +35,7 @@ func BenchmarkFilter(b *testing.B) {
 }
 
 func BenchmarkScanner(b *testing.B) {
+	b.ReportAllocs()
 	f, err := os.Open("fixtures/record1.mrc")
 	if err != nil {
 		b.Error(err)

--- a/marc_test.go
+++ b/marc_test.go
@@ -42,7 +42,7 @@ func BenchmarkScanner(b *testing.B) {
 	}
 	iter := NewMarcIterator(f)
 	_ = iter.Next()
-	bytes := iter.scanner.Bytes()
+	bytes := iter.scanner.Text()
 	for n := 0; n < b.N; n++ {
 		_, _ = iter.scanIntoRecord(bytes)
 	}


### PR DESCRIPTION
This reduces the number of heap allocations when scanning a record into
a Record struct. The total amount of heap requested probably won't
change much, but instead of doing it piecemeal it does it once for each
record. The overall performance improvement is about 30%.

This is almost an entirely internal optimization. The only aspect of the
public interface that changes is that a Record's Data field changes from
a byte slice to a string. I don't think mario is using this.

The first commit just enables heap allocation reporting on the benchmarks for comparison. You can see the stats by checking out `HEAD~1`:
```
$ git co HEAD~1
$ go test -bench .
$ git co heap-usage
$ go test -bench .
```

The only change you'll see is in the BenchmarkScanner test. Before:
```
BenchmarkScanner-4        112966	     11002 ns/op	    7552 B/op	     189 allocs/op
```
after:
```
BenchmarkScanner-4        163754	      7069 ns/op	    6224 B/op	      67 allocs/op
```
