### PR TITLE
Fix MARC record iteration bug

### DIFF
--- a/marc.go
+++ b/marc.go
@@ -282,11 +282,6 @@ func splitFunc(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	if atEOF && len(data) == 0 {
 		return 0, nil, nil
 	}
-
-	if atEOF {
-		return len(data), data, nil
-	}
-
 	if i := bytes.IndexByte(data, rt); i >= 0 {
 		return i + 1, data[0:i], nil
 	}


### PR DESCRIPTION
### Why these changes are being introduced

During iteration over records in a MARC file, if the scanner
encountered the end of file but the buffer still contained multiple
records, it would return the entire rest of the file instead of
splitting those records and returning each one. This resulted in the
number of records returned changing every time the iterator ran
on the same MARC file, because the buffer didn't always grab the
exact same number of bytes from the data so the number of records
grouped together that last chunk was slightly different each time.

### How this addresses that need
Removes the code that was returning the entire rest of the the file
as soon as the end of file was loaded into the buffer.

Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/DISCO-114